### PR TITLE
Small Typo in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ Yields:
 ```json
 {
   "type": "custom",
-  "value": "dats"
+  "value": "data"
 }
 ```
 


### PR DESCRIPTION
README had `dats`. This MR fixes the reference to correctly point to `data`.